### PR TITLE
Отображение плейсхолдера для пустого листа поиска

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/filters/areas/ui/RegionSelectFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filters/areas/ui/RegionSelectFragment.kt
@@ -132,6 +132,7 @@ class RegionSelectFragment : Fragment() {
 
     private fun showFilteredResult(request: String) {
         adapter.filterResults(request)
+        binding.notFoundPlaceholder.isVisible = adapter.list.isEmpty()
     }
 
     private fun showEmpty() {

--- a/app/src/main/java/ru/practicum/android/diploma/filters/areas/ui/presenter/RegionSelectRecyclerViewAdapter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filters/areas/ui/presenter/RegionSelectRecyclerViewAdapter.kt
@@ -11,6 +11,8 @@ class RegionSelectRecyclerViewAdapter(
 ) : RecyclerView.Adapter<AreaViewHolder>() {
 
     var list = mutableListOf<Area>()
+    private var previousList = mutableListOf<Area>()
+    private var previousRequest: String = ""
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AreaViewHolder {
         val view = LayoutInflater.from(parent.context)
@@ -31,11 +33,24 @@ class RegionSelectRecyclerViewAdapter(
     }
 
     fun filterResults(request: String) {
+        if (request.isNotEmpty()
+            && previousRequest.isNotEmpty()
+            && previousRequest.contains(request)
+        ) {
+            list.clear()
+            list.addAll(previousList)
+        }
+
         val filteredList = list.filter { area ->
             area.name
                 .lowercase()
                 .contains(request)
         }
+
+        previousList.clear()
+        previousList.addAll(list)
+        previousRequest = request
+
         list.clear()
         list.addAll(filteredList)
         notifyDataSetChanged()

--- a/app/src/main/java/ru/practicum/android/diploma/filters/industries/ui/presenter/IndustrySelectRecyclerViewAdapter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filters/industries/ui/presenter/IndustrySelectRecyclerViewAdapter.kt
@@ -12,6 +12,8 @@ class IndustrySelectRecyclerViewAdapter(
 
     var list = mutableListOf<Industry>()
     var lastSelect = 0
+    private var previousList = mutableListOf<Industry>()
+    private var previousRequest: String = ""
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IndustriesViewHolder {
         val view = LayoutInflater.from(parent.context)
@@ -39,11 +41,24 @@ class IndustrySelectRecyclerViewAdapter(
     }
 
     fun filterResults(request: String) {
+        if (request.isNotEmpty()
+            && previousRequest.isNotEmpty()
+            && previousRequest.contains(request)
+        ) {
+            list.clear()
+            list.addAll(previousList)
+        }
+
         val filteredList = list.filter { industry ->
             industry.name
                 .lowercase()
                 .contains(request)
         }
+
+        previousList.clear()
+        previousList.addAll(list)
+        previousRequest = request
+
         list.clear()
         list.addAll(filteredList)
         notifyDataSetChanged()


### PR DESCRIPTION
-Отображение плейсхолдера в регионах
-Добавил логику в поиск индустрий и регионов, если начать удалять поисковый запрос, то в листе отражаются предыдущие данные, а не пустой экран